### PR TITLE
Added button in Setup popup to move GI or TL to project

### DIFF
--- a/addons/Popochiu/Editor/MainDock/ObjectRow/PopochiuObjectRow.gd
+++ b/addons/Popochiu/Editor/MainDock/ObjectRow/PopochiuObjectRow.gd
@@ -138,8 +138,8 @@ func _ready() -> void:
 		)
 	elif type == Constants.Types.PROP and path.find('.gd') > -1:
 		# If the Room object has a script, disable the Create prop script button
-		_menu_popup.set_item_disabled(
-			_menu_popup.get_item_index(MenuOptions.CREATE_PROP_SCRIPT), true
+		_menu_popup.remove_item(
+			_menu_popup.get_item_index(MenuOptions.CREATE_PROP_SCRIPT)
 		)
 	
 	# Hide buttons based on the type of the Object this row represents
@@ -186,6 +186,12 @@ func show_create_state_script() -> void:
 	_btn_state_script.disabled = true
 	_menu_popup.set_item_disabled(
 		_menu_popup.get_item_index(MenuOptions.CREATE_STATE_SCRIPT), false
+	)
+
+
+func remove_create_state_script() -> void:
+	_menu_popup.remove_item(
+		_menu_popup.get_item_index(MenuOptions.CREATE_STATE_SCRIPT)
 	)
 
 

--- a/addons/Popochiu/Editor/MainDock/PopochiuDock.gd
+++ b/addons/Popochiu/Editor/MainDock/PopochiuDock.gd
@@ -183,6 +183,8 @@ func fill_data() -> void:
 				
 				if not has_state_script:
 					row.show_create_state_script()
+				else:
+					row.remove_create_state_script()
 	
 	# Load other tabs data
 	_tab_audio.fill_data()

--- a/addons/Popochiu/Editor/MainDock/PopochiuDock.tscn
+++ b/addons/Popochiu/Editor/MainDock/PopochiuDock.tscn
@@ -69,14 +69,14 @@ custom_constants/margin_bottom = 4
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 margin_left = 4.0
 margin_top = 4.0
-margin_right = 335.0
+margin_right = 339.0
 margin_bottom = 176.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 2
 
 [node name="TabContainer" type="TabContainer" parent="MarginContainer/VBoxContainer"]
-margin_right = 331.0
+margin_right = 335.0
 margin_bottom = 140.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -100,7 +100,7 @@ __meta__ = {
 }
 
 [node name="MainScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer/TabContainer/Main"]
-margin_right = 323.0
+margin_right = 327.0
 margin_bottom = 104.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -108,13 +108,13 @@ follow_focus = true
 scroll_horizontal_enabled = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer"]
-margin_right = 311.0
+margin_right = 315.0
 margin_bottom = 108.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="RoomsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource( 4 )]
-margin_right = 311.0
+margin_right = 315.0
 icon = ExtResource( 10 )
 color = Color( 0.439216, 0.427451, 0.921569, 0.498039 )
 title = "Rooms"
@@ -122,7 +122,7 @@ create_text = "Create room"
 
 [node name="CharactersGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 28.0
-margin_right = 311.0
+margin_right = 315.0
 margin_bottom = 52.0
 icon = ExtResource( 8 )
 color = Color( 0.929412, 0.945098, 0.443137, 0.498039 )
@@ -131,7 +131,7 @@ create_text = "Create character"
 
 [node name="ItemsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 56.0
-margin_right = 311.0
+margin_right = 315.0
 margin_bottom = 80.0
 icon = ExtResource( 11 )
 color = Color( 0.337255, 0.67451, 0.301961, 0.498039 )
@@ -140,7 +140,7 @@ create_text = "Create item"
 
 [node name="DialogsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 84.0
-margin_right = 311.0
+margin_right = 315.0
 margin_bottom = 108.0
 icon = ExtResource( 9 )
 color = Color( 0.458824, 0.807843, 0.784314, 0.498039 )
@@ -165,44 +165,44 @@ focus_mode = 2
 
 [node name="FooterPanel" type="PanelContainer" parent="MarginContainer/VBoxContainer"]
 margin_top = 142.0
-margin_right = 331.0
+margin_right = 335.0
 margin_bottom = 172.0
 custom_styles/panel = SubResource( 10 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/FooterPanel"]
 margin_left = 4.0
 margin_top = 4.0
-margin_right = 327.0
+margin_right = 331.0
 margin_bottom = 26.0
 size_flags_vertical = 3
 alignment = 2
 
 [node name="Version" type="Label" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 margin_top = 4.0
-margin_right = 35.0
+margin_right = 39.0
 margin_bottom = 18.0
 size_flags_horizontal = 3
-text = "v1.?.?"
+text = "v1.9.0"
 
 [node name="BtnSetup" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
-margin_left = 39.0
-margin_right = 105.0
+margin_left = 43.0
+margin_right = 109.0
 margin_bottom = 22.0
 hint_tooltip = "Opens wiki in web browser"
 text = "Setup"
 icon = SubResource( 12 )
 
 [node name="BtnSettings" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
-margin_left = 109.0
-margin_right = 190.0
+margin_left = 113.0
+margin_right = 194.0
 margin_bottom = 22.0
 hint_tooltip = "Opens wiki in web browser"
 text = "Settings"
 icon = SubResource( 12 )
 
 [node name="BtnDocs" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
-margin_left = 194.0
-margin_right = 323.0
+margin_left = 198.0
+margin_right = 327.0
 margin_bottom = 22.0
 hint_tooltip = "Opens wiki in web browser"
 text = "Documentation"

--- a/addons/Popochiu/Editor/MainDock/TabAudio.gd
+++ b/addons/Popochiu/Editor/MainDock/TabAudio.gd
@@ -235,8 +235,8 @@ func _create_audio_file_row(file_path: String) -> void:
 	_audio_files_to_assign.append(file_path)
 
 
-func _create_audio_cue(\
-type: String, path: String, audio_row: Container = null
+func _create_audio_cue(
+	type: String, path: String, audio_row: Container = null
 ) -> void:
 	var cue_name := path.get_file().get_basename()
 	var cue_file_name := U.snake2pascal(cue_name)

--- a/addons/Popochiu/Editor/Popups/Setup/Setup.gd
+++ b/addons/Popochiu/Editor/Popups/Setup/Setup.gd
@@ -1,6 +1,8 @@
 tool
 extends AcceptDialog
 
+signal move_requested(id)
+
 const ImporterDefaults :=\
 preload('res://addons/Popochiu/Engine/Others/ImporterDefaults.gd')
 const SCALE_MESSAGE :=\
@@ -19,6 +21,9 @@ onready var _game_height: SpinBox = find_node('GameHeight')
 onready var _test_width: SpinBox = find_node('TestWidth')
 onready var _test_height: SpinBox = find_node('TestHeight')
 onready var _game_type: OptionButton = find_node('GameType')
+onready var _advanced: HBoxContainer = find_node('Advanced')
+onready var _btn_move_gi: Button = find_node('BtnMoveGI')
+onready var _btn_move_tl: Button = find_node('BtnMoveTL')
 onready var _btn_update_imports: Button = find_node('BtnUpdateFiles')
 
 
@@ -28,9 +33,14 @@ func _ready() -> void:
 	connect('popup_hide', self, '_update_project_settings')
 	_game_width.connect('value_changed', self, '_update_scale')
 	_game_height.connect('value_changed', self, '_update_scale')
+	_btn_move_gi.connect('pressed', self, '_move_gi')
+	_btn_move_tl.connect('pressed', self, '_move_tl')
 	_btn_update_imports.connect('pressed', self, '_update_imports')
 	
 	# Set default state
+	_advanced.hide()
+	_btn_move_gi.hide()
+	_btn_move_tl.hide()
 	_btn_update_imports.hide()
 
 
@@ -50,6 +60,8 @@ func appear(show_welcome := false) -> void:
 	if show_welcome:
 		_welcome.show()
 		_welcome_separator.show()
+	else:
+		update_state()
 	
 	# Set initial values for fields
 	_game_width.value = ProjectSettings.get_setting(PopochiuResources.DISPLAY_WIDTH)
@@ -74,6 +86,19 @@ func appear(show_welcome := false) -> void:
 	
 	popup_centered_minsize(Vector2(480.0, 180.0))
 	get_ok().text = 'Close'
+
+
+func update_state() -> void:
+	_advanced.hide()
+	_btn_move_gi.hide()
+	
+	if not PopochiuResources.get_data_value('setup', 'gi_moved', false):
+		_advanced.show()
+		_btn_move_gi.show()
+	
+	if not PopochiuResources.get_data_value('setup', 'tl_moved', false):
+		_advanced.show()
+		_btn_move_tl.show()
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
@@ -120,6 +145,16 @@ func _get_scale_msg() -> String:
 		('light' if es.get_setting('interface/theme/preset').find('Light') > -1\
 		else 'dark'),
 	]
+
+
+func _move_gi() -> void:
+	_btn_move_gi.disabled = true
+	emit_signal('move_requested', PopochiuResources.GI)
+
+
+func _move_tl() -> void:
+	_btn_move_tl.disabled = true
+	emit_signal('move_requested', PopochiuResources.TL)
 
 
 func _update_imports() -> void:

--- a/addons/Popochiu/Editor/Popups/Setup/Setup.tscn
+++ b/addons/Popochiu/Editor/Popups/Setup/Setup.tscn
@@ -26,7 +26,6 @@ corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [node name="Setup" type="AcceptDialog"]
-visible = true
 margin_right = 320.0
 margin_bottom = 178.0
 window_title = "Popochiu setup"
@@ -239,11 +238,58 @@ text = "Pixel"
 items = [ "Default", null, false, 0, null, "2D", null, false, 1, null, "Pixel", null, false, 2, null ]
 selected = 2
 
+[node name="Advanced" type="HBoxContainer" parent="VBoxContainer"]
+visible = false
+margin_top = 243.0
+margin_right = 304.0
+margin_bottom = 275.0
+rect_min_size = Vector2( 0, 32 )
+
+[node name="LeftSeparator" type="HSeparator" parent="VBoxContainer/Advanced"]
+margin_right = 117.0
+margin_bottom = 32.0
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="VBoxContainer/Advanced"]
+margin_left = 121.0
+margin_top = 9.0
+margin_right = 183.0
+margin_bottom = 23.0
+text = "Advanced"
+
+[node name="RightSeparator" type="HSeparator" parent="VBoxContainer/Advanced"]
+margin_left = 187.0
+margin_right = 304.0
+margin_bottom = 32.0
+size_flags_horizontal = 3
+
+[node name="BtnMoveGI" type="Button" parent="VBoxContainer"]
+visible = false
+margin_left = 71.0
+margin_top = 279.0
+margin_right = 232.0
+margin_bottom = 311.0
+rect_min_size = Vector2( 0, 32 )
+hint_tooltip = "Move res://addons/Popochiu/Engine/Objects/GraphicInterface/ to res://popochiu/GraphicInterface/ so you can modify the default GUI."
+size_flags_horizontal = 4
+text = "Move Graphic Interface"
+
+[node name="BtnMoveTL" type="Button" parent="VBoxContainer"]
+visible = false
+margin_left = 71.0
+margin_top = 279.0
+margin_right = 232.0
+margin_bottom = 311.0
+rect_min_size = Vector2( 0, 32 )
+hint_tooltip = "Move res://addons/Popochiu/Engine/Objects/GraphicInterface/ to res://popochiu/GraphicInterface/ so you can modify the default GUI."
+size_flags_horizontal = 4
+text = "Move Transition Layer"
+
 [node name="BtnUpdateFiles" type="Button" parent="VBoxContainer"]
 visible = false
-margin_top = 192.0
+margin_top = 243.0
 margin_right = 304.0
-margin_bottom = 224.0
+margin_bottom = 275.0
 rect_min_size = Vector2( 0, 32 )
 hint_tooltip = "Browse the file system for .import files of images, and update them to match the current Game type selection.
 

--- a/addons/Popochiu/Engine/AudioManager/AudioManager.gd
+++ b/addons/Popochiu/Engine/AudioManager/AudioManager.gd
@@ -39,8 +39,9 @@ func _ready() -> void:
 # If wait_to_end is not null, that means the call is comming from a play
 # inside a E.run([])
 # In this method the calls to play and play_no_block converge.
-func play_sound_cue(\
-cue_name := '', position_2d := Vector2.ZERO, wait_to_end = null) -> Node:
+func play_sound_cue(
+	cue_name := '', position_2d := Vector2.ZERO, wait_to_end = null
+) -> Node:
 	var stream_player: Node = null
 	
 	if _all_in_one.has(cue_name.to_lower()):
@@ -64,8 +65,9 @@ cue_name := '', position_2d := Vector2.ZERO, wait_to_end = null) -> Node:
 
 # Looks for an AudioCue in the list of music cues and plays it.
 # In this method the calls to play_music and play_music_no_block converge.
-func play_music_cue(\
-cue_name: String, fade_duration := 0.0, music_position := 0.0) -> Node:
+func play_music_cue(
+	cue_name: String, fade_duration := 0.0, music_position := 0.0
+) -> Node:
 	var stream_player: Node = null
 	
 	if _active.has(cue_name):

--- a/addons/Popochiu/Engine/Interfaces/ICharacter.gd
+++ b/addons/Popochiu/Engine/Interfaces/ICharacter.gd
@@ -44,8 +44,9 @@ func player_say_no_block(dialog: String, call_done := true) -> void:
 
 
 # Makes a character (script_name) walk to a position in the current room.
-func character_walk_to(\
-chr_name: String, position: Vector2, is_in_queue := true) -> void:
+func character_walk_to(
+	chr_name: String, position: Vector2, is_in_queue := true
+) -> void:
 	if is_in_queue: yield()
 	
 	var walking_character: PopochiuCharacter = get_character(chr_name)
@@ -131,8 +132,9 @@ func change_camera_owner(c: PopochiuCharacter, is_in_queue := true) -> void:
 	yield(get_tree(), 'idle_frame')
 
 
-func set_character_emotion(\
-chr_name: String, emotion: String, is_in_queue := true) -> void:
+func set_character_emotion(
+	chr_name: String, emotion: String, is_in_queue := true
+) -> void:
 	if is_in_queue: yield()
 	
 	if get_character(chr_name):

--- a/addons/Popochiu/Engine/Popochiu.gd
+++ b/addons/Popochiu/Engine/Popochiu.gd
@@ -391,8 +391,9 @@ func camera_offset(offset := Vector2.ZERO, is_in_queue := true) -> void:
 
 
 # Makes the camera shake with strength for duration seconds
-func camera_shake(\
-strength := 1.0, duration := 1.0, is_in_queue := true) -> void:
+func camera_shake(
+	strength := 1.0, duration := 1.0, is_in_queue := true
+) -> void:
 	if is_in_queue: yield()
 	
 	_camera_shake_amount = strength
@@ -404,8 +405,9 @@ strength := 1.0, duration := 1.0, is_in_queue := true) -> void:
 
 # Makes the camera shake with strength for duration seconds without blocking
 # excecution
-func camera_shake_no_block(\
-strength := 1.0, duration := 1.0, is_in_queue := true) -> void:
+func camera_shake_no_block(
+	strength := 1.0, duration := 1.0, is_in_queue := true
+) -> void:
 	if is_in_queue: yield()
 	
 	_camera_shake_amount = strength
@@ -418,8 +420,9 @@ strength := 1.0, duration := 1.0, is_in_queue := true) -> void:
 # Changes the camera zoom. If target is larger than Vector2(1, 1) the camera
 # will zoom out, smaller values make it zoom in. The effect will last duration
 # seconds
-func camera_zoom(\
-target := Vector2.ONE, duration := 1.0, is_in_queue := true) -> void:
+func camera_zoom(
+	target := Vector2.ONE, duration := 1.0, is_in_queue := true
+) -> void:
 	if is_in_queue: yield()
 	
 	$Tween.interpolate_property(

--- a/addons/Popochiu/PopochiuInspectorPlugin.gd
+++ b/addons/Popochiu/PopochiuInspectorPlugin.gd
@@ -108,13 +108,14 @@ func _find_polygon_instance(object: Object) -> void:
 	ei.edit_node(children[0])
 
 
-func parse_property(\
-object: Object,
-type: int,
-path: String,
-hint: int,
-hint_text: String,
-usage: int) -> bool:
+func parse_property(
+	object: Object,
+	type: int,
+	path: String,
+	hint: int,
+	hint_text: String,
+	usage: int
+) -> bool:
 	if object and object.get_parent() is YSort and path != 'position':
 		return true
 	

--- a/addons/Popochiu/PopochiuResources.gd
+++ b/addons/Popochiu/PopochiuResources.gd
@@ -54,7 +54,9 @@ const C_SNGL := 'res://popochiu/Autoloads/C.gd'
 const I_SNGL := 'res://popochiu/Autoloads/I.gd'
 const D_SNGL := 'res://popochiu/Autoloads/D.gd'
 const A_SNGL := 'res://popochiu/Autoloads/A.gd'
-# ════ FIRST INSTALL ═══════════════════════════════════════════════════════════
+# ════ MOVE ════════════════════════════════════════════════════════════════════
+const GI := 0
+const TL := 1
 const GRAPHIC_INTERFACE_ADDON :=\
 'res://addons/Popochiu/Engine/Objects/GraphicInterface/GraphicInterface.tscn'
 const GRAPHIC_INTERFACE_POPOCHIU :=\


### PR DESCRIPTION
Pressing this buttons will move the GraphicInterface or the TransitionLayer folders from the addon to the project, so devs can modify either of them to customize their game. Buttons in context menus related with scripts (Create state script, Create script) are removed instead of disabled.