### PR TITLE
Add walk_to_clicked to PopochiuCharacter

### DIFF
--- a/addons/popochiu/engine/interfaces/i_character.gd
+++ b/addons/popochiu/engine/interfaces/i_character.gd
@@ -22,9 +22,7 @@ func queue_walk_to_clicked() -> Callable:
 # of the last clicked PopochiuClickable (e.g. a PopochiuProp, a PopochiuHotspot,
 # another PopochiuCharacter, etc.) in the room.
 func walk_to_clicked() -> void:
-	await player.walk(
-		(E.clicked as PopochiuClickable).to_global(E.clicked.walk_to_point)
-	)
+	await player.walk_to_clicked()
 
 
 # Queues the call to face_clicked()

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -277,9 +277,15 @@ func queue_walk_to(pos: Vector2) -> Callable:
 
 
 func walk_to(pos: Vector2) -> void:
-	walk(E.current_room.to_global(pos))
-	
-	await C.character_move_ended
+	await walk(E.current_room.to_global(pos))
+
+
+func queue_walk_to_clicked() -> Callable:
+	return func (): await walk_to_clicked()
+
+
+func walk_to_clicked() -> void:
+	await _walk_to_clickable(E.clicked as PopochiuClickable)
 
 
 func queue_walk_to_prop(id: String) -> Callable:
@@ -287,9 +293,7 @@ func queue_walk_to_prop(id: String) -> Callable:
 
 
 func walk_to_prop(id: String) -> void:
-	_walk_to_clickable(E.current_room.get_prop(id))
-	
-	await C.character_move_ended
+	await _walk_to_clickable(E.current_room.get_prop(id))
 
 
 func queue_walk_to_hotspot(id: String) -> Callable:
@@ -297,9 +301,7 @@ func queue_walk_to_hotspot(id: String) -> Callable:
 
 
 func walk_to_hotspot(id: String) -> void:
-	_walk_to_clickable(E.current_room.get_hotspot(id))
-	
-	await C.character_move_ended
+	await _walk_to_clickable(E.current_room.get_hotspot(id))
 
 
 func queue_walk_to_marker(id: String) -> Callable:
@@ -307,9 +309,7 @@ func queue_walk_to_marker(id: String) -> Callable:
 
 
 func walk_to_marker(id: String) -> void:
-	walk(E.current_room.get_point(id))
-
-	await C.character_move_ended
+	await walk(E.current_room.get_point(id))
 
 
 func queue_set_emotion(new_emotion: String) -> Callable:
@@ -502,4 +502,4 @@ func _walk_to_clickable(node: PopochiuClickable) -> void:
 		await get_tree().process_frame
 		return
 
-	walk(node.to_global(node.walk_to_point))
+	await walk(node.to_global(node.walk_to_point))


### PR DESCRIPTION
Hotspot and Prop template have `await C.player.walk_to_clicked()` as suggested code in their `_on_click`. But `walk_to_clicked` currently only exist on character interface itself, not on a character instance. Added that method to the character class.

Additionally in `walk_to_prop`, `walk_to_hotspot` and `walk_to_marker` made them await the walk call itself and not `C.character_move_ended` (which is already waited on in `walk`).

(And I think it makes sense to wait for a character's `stopped_walk` signal instead of interface's `character_move_ended` since the latter might concern another character, but have not touched it.)

Now that I think about it, maybe it makes sense to add an optional argument for offset to `walk_to_clicked`, `walk_to_prop` and `walk_to_hotspot` since if multiple characters can go to the same object it makes sense to place them not at the same exact position.