### PR TITLE
Finish transition from point to marker

### DIFF
--- a/addons/popochiu/editor/main_dock/tab_room.gd
+++ b/addons/popochiu/editor/main_dock/tab_room.gd
@@ -39,7 +39,7 @@ var _remove_dialog: ConfirmationDialog
 		type_class = PopochiuRegion,
 		parent = 'Regions'
 	},
-	Constants.Types.POINT: {
+	Constants.Types.MARKER: {
 		group = find_child('MarkersGroup'),
 		method = 'get_markers',
 		type_class = Marker2D,

--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -23,8 +23,12 @@ func get_walkable_area(walkable_area_name: String) -> PopochiuWalkableArea:
 	return current.get_walkable_area(walkable_area_name)
 
 
-func get_point(point_name: String) -> Vector2:
-	return current.get_point(point_name)
+func get_marker(marker_name: String) -> Marker2D:
+	return current.get_marker(marker_name)
+
+
+func get_marker_position(marker_name: String) -> Vector2:
+	return current.get_marker_position(marker_name)
 
 
 func get_props() -> Array:

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -285,7 +285,7 @@ func queue_walk_to_clicked(offset := Vector2.ZERO) -> Callable:
 
 
 func walk_to_clicked(offset := Vector2.ZERO) -> void:
-	await _walk_to_clickable(E.clicked, offset)
+	await _walk_to_node(E.clicked, offset)
 
 
 func queue_walk_to_prop(id: String, offset := Vector2.ZERO) -> Callable:
@@ -293,7 +293,7 @@ func queue_walk_to_prop(id: String, offset := Vector2.ZERO) -> Callable:
 
 
 func walk_to_prop(id: String, offset := Vector2.ZERO) -> void:
-	await _walk_to_clickable(E.current_room.get_prop(id), offset)
+	await _walk_to_node(E.current_room.get_prop(id), offset)
 
 
 func queue_walk_to_hotspot(id: String, offset := Vector2.ZERO) -> Callable:
@@ -301,7 +301,7 @@ func queue_walk_to_hotspot(id: String, offset := Vector2.ZERO) -> Callable:
 
 
 func walk_to_hotspot(id: String, offset := Vector2.ZERO) -> void:
-	await _walk_to_clickable(E.current_room.get_hotspot(id), offset)
+	await _walk_to_node(E.current_room.get_hotspot(id), offset)
 
 
 func queue_walk_to_marker(id: String, offset := Vector2.ZERO) -> Callable:
@@ -309,7 +309,7 @@ func queue_walk_to_marker(id: String, offset := Vector2.ZERO) -> Callable:
 
 
 func walk_to_marker(id: String, offset := Vector2.ZERO) -> void:
-	await walk(E.current_room.get_point(id) + offset)
+	await _walk_to_node(E.current_room.get_marker(id), offset)
 
 
 func queue_set_emotion(new_emotion: String) -> Callable:
@@ -497,9 +497,9 @@ func _get_valid_oriented_animation(animation_label):
 	return null
 
 
-func _walk_to_clickable(node: PopochiuClickable, offset: Vector2) -> void:
+func _walk_to_node(node: Node2D, offset: Vector2) -> void:
 	if not is_instance_valid(node):
 		await get_tree().process_frame
 		return
 
-	await walk(node.to_global(node.walk_to_point) + offset)
+	await walk(node.to_global(node.walk_to_point if node is PopochiuClickable else Vector2.ZERO) + offset)

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -160,12 +160,17 @@ func clean_characters() -> void:
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ SET & GET ░░░░
-func get_marker(marker_name: String) -> Vector2:
+func get_marker(marker_name: String) -> Marker2D:
 	var marker: Marker2D = get_node_or_null('Markers/' + marker_name)
 	if marker:
-		return marker.global_position
+		return marker
 	printerr('[Popochiu] Marker %s not found' % marker_name)
-	return Vector2.ZERO
+	return null
+
+
+func get_marker_position(marker_name: String) -> Vector2:
+	var marker := get_marker(marker_name)
+	return marker.global_position if marker != null else Vector2.ZERO
 
 
 func get_prop(prop_name: String) -> PopochiuProp:

--- a/addons/popochiu/popochiu_resources.gd
+++ b/addons/popochiu/popochiu_resources.gd
@@ -10,7 +10,7 @@ enum Types {
 	PROP,
 	HOTSPOT,
 	REGION,
-	POINT,
+	MARKER,
 	WALKABLE_AREA
 }
 enum CursorType {
@@ -34,7 +34,7 @@ const MAIN_DOCK_PATH := 'res://addons/popochiu/editor/main_dock/popochiu_dock.ts
 const MAIN_TYPES := [
 	Types.ROOM, Types.CHARACTER, Types.INVENTORY_ITEM, Types.DIALOG
 ]
-const ROOM_TYPES := [Types.PROP, Types.HOTSPOT, Types.REGION, Types.POINT, Types.WALKABLE_AREA]
+const ROOM_TYPES := [Types.PROP, Types.HOTSPOT, Types.REGION, Types.MARKER, Types.WALKABLE_AREA]
 const WIKI := 'https://github.com/mapedorr/popochiu/wiki/'
 const CFG := 'res://addons/popochiu/plugin.cfg'
 # ════ SINGLETONS ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
There is unfinished migration in naming from Point to Marker in 2.0. Some of it just names, but some does create errors - like calls to non-existent method `get_point` on a room (it is called now `get_marker`).

- Rename `Constants.Types.POINT` to `Constants.Types.MARKER`.
- In Room interface remove `get_point`, add `get_marker` and `get_marker_position`.
- In Character class make `walk_to_marker` consistent with other walk_to methods - if marker does not exist, do not move.
- In Room class make `get_marker` return `Marker2D` (you get what you ask, plus `get_markers` return array of those too, marker can provide scale or rotation, so there is a value in it), add `get_marker_position` to match old `get_point` behavior.

Alternatively, `get_marker_position` can be named `get_point` to match old name. Thoughts?