### PR TITLE
#87 Add warning when loop metadata is missing for AudioStreamWAV

### DIFF
--- a/addons/popochiu/engine/audio_manager/audio_cue.gd
+++ b/addons/popochiu/engine/audio_manager/audio_cue.gd
@@ -93,9 +93,12 @@ func set_loop(value: bool) -> void:
 		'AudioStreamOggVorbis', 'AudioStreamMP3':
 			audio.loop = value
 		'AudioStreamWAV':
-			(audio as AudioStreamWAV).loop_mode =\
-			AudioStreamWAV.LOOP_FORWARD if value\
-			else AudioStreamWAV.LOOP_DISABLED
+			if (audio as AudioStreamWAV).get_loop_end() == 0 && value:
+				push_warning("res://addons/popochiu/engine/audio_manager/audio_cue.gd:97 " + resource_name + " does not have the correct metadata for loop, please check AudioStreamWAV documentation")
+			else:
+				(audio as AudioStreamWAV).loop_mode =\
+				AudioStreamWAV.LOOP_FORWARD if value\
+				else AudioStreamWAV.LOOP_DISABLED
 	
 	notify_property_list_changed()
 

--- a/addons/popochiu/engine/audio_manager/audio_cue.gd
+++ b/addons/popochiu/engine/audio_manager/audio_cue.gd
@@ -94,7 +94,11 @@ func set_loop(value: bool) -> void:
 			audio.loop = value
 		'AudioStreamWAV':
 			if (audio as AudioStreamWAV).get_loop_end() == 0 && value:
-				push_warning("res://addons/popochiu/engine/audio_manager/audio_cue.gd:97 " + resource_name + " does not have the correct metadata for loop, please check AudioStreamWAV documentation")
+				PopochiuUtils.print_warning(
+					"[b]%s[/b]" % resource_name +\
+					" does not have the correct metadata to loop, please check" +\
+					" AudioStreamWAV documentation"
+				)
 			else:
 				(audio as AudioStreamWAV).loop_mode =\
 				AudioStreamWAV.LOOP_FORWARD if value\


### PR DESCRIPTION
This PR is for issue #87 

**What**
This PR adds a warning in the Godot console to help developers notice that the WAV file added does not have the correct metadata to loop

**Why**
Is not a bug from Popochiu per se, according to https://github.com/godotengine/godot/issues/40359 if the metadata is not present a WAV file won't loop.
