### PR TITLE
Popochiu 2 - Alpha 4

### DIFF
--- a/LEEME.md
+++ b/LEEME.md
@@ -4,7 +4,7 @@
 
 ![cover](https://github.com/mapedorr/popochiu/wiki/images/popochiu_2_hero-es.png "Popochiu")
 
-Un plugin para Godot que permite crear juegos de aventura gráfica con un flujo de trabajo como el de [Adventure Game Studio](https://www.adventuregamestudio.co.uk/) y [PowerQuest](https://powerhoof.itch.io/powerquest).
+Un plugin para Godot que permite crear juegos de aventura gráfica fácilmente con un flujo de trabajo como el de [Adventure Game Studio](https://www.adventuregamestudio.co.uk/) y [PowerQuest](https://powerhoof.itch.io/powerquest).
 
 ### 🌎 [Read this in English](./README.md) 🌎
 
@@ -30,7 +30,7 @@ Esta herramienta consta de dos partes: el núcleo (Popochiu) y el dock que facil
 
 **Popochiu puede usarse en Godot 3.3.x a 3.5.x**. **¡¡¡Y ahora también funciona en Godot 4!!!**
 
-1. Si usas Godot 4, descarga [Popochiu 2.0 Alpha 3](https://github.com/mapedorr/popochiu/releases/download/v2.0-alpha3/popochiu_v2.0-alpha3.zip). Si usas **Godot 3.5 o superior**, descarga [Popochiu 1.10](https://github.com/mapedorr/popochiu/releases/download/v1.10.0/popochiu-v1.10.0.zip). Si estás usando **Godot 3.3 a Godot 3.4.5**, descarga [Popochiu 1.8.7](https://github.com/mapedorr/popochiu/releases/download/v1.8.7/popochiu-v1.8.7.zip).
+1. Si usas Godot 4, descarga [Popochiu 2.0 Alpha 4](https://github.com/mapedorr/popochiu/releases/download/v2.0-alpha4/popochiu_v2.0-alpha4.zip). Si usas **Godot 3.5 o superior**, descarga [Popochiu 1.10](https://github.com/mapedorr/popochiu/releases/download/v1.10.0/popochiu-v1.10.0.zip). Si estás usando **Godot 3.3 a Godot 3.4.5**, descarga [Popochiu 1.8.7](https://github.com/mapedorr/popochiu/releases/download/v1.8.7/popochiu-v1.8.7.zip).
 2. Extra su contenido y copia la carpeta `addons` dentro de la carpeta de tu proyecto.
 3. Abre tu proyecto en Godot y habilita el plugin Popochiu: `Proyecto > Ajustes del Proyecto > Plugins` (the tab on the top).
 4. Reinicia Godot `Proyecto > Volver a Cargar el Proyecto Actual`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![cover](https://github.com/mapedorr/popochiu/wiki/images/popochiu_2_hero-en.png "Popochiu")
 
-A Godot plugin to create point n' click games with a workflow similar to [Adventure Game Studio](https://www.adventuregamestudio.co.uk/) and [PowerQuest](https://powerhoof.itch.io/powerquest).
+A Godot plugin to make point n' click games the easy way with a workflow similar to [Adventure Game Studio](https://www.adventuregamestudio.co.uk/) and [PowerQuest](https://powerhoof.itch.io/powerquest).
 
 ### 🌎👉🏽 [Lee la versión en Español](./LEEME.md) 👈🏽🌎
 
@@ -30,7 +30,7 @@ This tool consists of two parts: the core (Popochiu) and the dock that helps wit
 
 **Popochiu works on Godot 3.3.x to 3.5.x**. **And now in Godot 4 too!!!**
 
-1. Godot 4 users can download [Popochiu 2.0 Alpha 3](https://github.com/mapedorr/popochiu/releases/download/v3.0-alpha3/popochiu_v3.0-alpha3.zip). If you are using **Godot 3.5 onwards**, download [Popochiu 1.10](https://github.com/mapedorr/popochiu/releases/download/v1.10.0/popochiu-v1.10.0.zip). If you are using **Godot 3.3 to Godot 3.4.5**, download [Popochiu 1.8.7](https://github.com/mapedorr/popochiu/releases/download/v1.8.7/popochiu-v1.8.7.zip).
+1. Godot 4 users can download [Popochiu 2.0 Alpha 4](https://github.com/mapedorr/popochiu/releases/download/v2.0-alpha4/popochiu_v2.0-alpha4.zip). If you are using **Godot 3.5 onwards**, download [Popochiu 1.10](https://github.com/mapedorr/popochiu/releases/download/v1.10.0/popochiu-v1.10.0.zip). If you are using **Godot 3.3 to Godot 3.4.5**, download [Popochiu 1.8.7](https://github.com/mapedorr/popochiu/releases/download/v1.8.7/popochiu-v1.8.7.zip).
 2. Extract it and copy the `addons` folder into your project folder.
 3. Open your Godot project and enable the Popochiu plugin: `Project > Project Settings... > Plugins` (the tab on the top).
 4. Restart Godot `Project > Reload Current Project`.

--- a/addons/popochiu/editor/main_dock/object_row/popochiu_object_row.gd
+++ b/addons/popochiu/editor/main_dock/object_row/popochiu_object_row.gd
@@ -290,7 +290,6 @@ func _menu_item_pressed(id: int) -> void:
 				settings.items_on_start.append(name)
 			
 			PopochiuResources.save_settings(settings)
-			(main_dock.ei as EditorInterface).get_inspector().refresh()
 			
 			self.is_on_start = name in settings.items_on_start
 		MenuOptions.CREATE_PROP_SCRIPT:

--- a/addons/popochiu/editor/main_dock/popochiu_dock.tscn
+++ b/addons/popochiu/editor/main_dock/popochiu_dock.tscn
@@ -21,19 +21,19 @@
 [ext_resource type="PackedScene" uid="uid://dbqppogchdate" path="res://addons/popochiu/editor/popups/setup/setup.tscn" id="18"]
 [ext_resource type="PackedScene" uid="uid://c054k1ux04waq" path="res://addons/popochiu/editor/popups/create_walkable_area/create_walkable_area.tscn" id="19"]
 
-[sub_resource type="Image" id="Image_66yk4"]
+[sub_resource type="Image" id="Image_uchp8"]
 data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
+"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
 "height": 16,
 "mipmaps": false,
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_fi3iu"]
-image = SubResource("Image_66yk4")
+[sub_resource type="ImageTexture" id="ImageTexture_jd3rb"]
+image = SubResource("Image_uchp8")
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ahs1a"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ce6p7"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -43,7 +43,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.439216, 0.427451, 0.921569, 0.74902)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bccaf"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x1dqg"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -53,7 +53,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.556863, 0.313726, 0.160784, 0.74902)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gksij"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_02hx0"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -63,7 +63,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.337255, 0.67451, 0.301961, 0.74902)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7efei"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_73yk6"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -75,7 +75,7 @@ border_color = Color(0.556863, 0.235294, 0.592157, 0.74902)
 
 [node name="Popochiu" type="Panel"]
 clip_contents = true
-custom_minimum_size = Vector2(392, 0)
+custom_minimum_size = Vector2(408, 0)
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -110,7 +110,7 @@ focus_mode = 2
 layout_mode = 2
 placeholder_text = "Filter Popochiu objects"
 clear_button_enabled = true
-right_icon = SubResource("ImageTexture_fi3iu")
+right_icon = SubResource("ImageTexture_jd3rb")
 script = ExtResource("2_i87mb")
 
 [node name="MainScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer/TabContainer/Main"]
@@ -126,7 +126,7 @@ size_flags_vertical = 3
 
 [node name="RoomsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_ahs1a")
+theme_override_styles/panel = SubResource("StyleBoxFlat_ce6p7")
 icon = ExtResource("3_uwncn")
 color = Color(0.439216, 0.427451, 0.921569, 0.74902)
 title = "Rooms"
@@ -134,7 +134,7 @@ create_text = "Create room"
 
 [node name="CharactersGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_bccaf")
+theme_override_styles/panel = SubResource("StyleBoxFlat_x1dqg")
 icon = ExtResource("4_h14xk")
 color = Color(0.556863, 0.313726, 0.160784, 0.74902)
 title = "Characters"
@@ -142,7 +142,7 @@ create_text = "Create character"
 
 [node name="ItemsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_gksij")
+theme_override_styles/panel = SubResource("StyleBoxFlat_02hx0")
 icon = ExtResource("5_ritjh")
 color = Color(0.337255, 0.67451, 0.301961, 0.74902)
 title = "Inventory items"
@@ -150,7 +150,7 @@ create_text = "Create inventory item"
 
 [node name="DialogsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_7efei")
+theme_override_styles/panel = SubResource("StyleBoxFlat_73yk6")
 icon = ExtResource("6_evjo7")
 color = Color(0.556863, 0.235294, 0.592157, 0.74902)
 title = "Dialog trees"
@@ -177,58 +177,79 @@ alignment = 2
 [node name="Version" type="Label" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "v2.0.0"
+text = "v2.0-alpha_4"
 
 [node name="BtnSetup" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Setup"
-icon = SubResource("ImageTexture_fi3iu")
+icon = SubResource("ImageTexture_jd3rb")
 
 [node name="BtnSettings" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Settings"
-icon = SubResource("ImageTexture_fi3iu")
+icon = SubResource("ImageTexture_jd3rb")
 
 [node name="BtnDocs" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Documentation"
-icon = SubResource("ImageTexture_fi3iu")
+icon = SubResource("ImageTexture_jd3rb")
 
 [node name="Popups" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 0
 
 [node name="CreateRoom" parent="Popups" instance=ExtResource("3")]
+max_size = Vector2i(1280, 720)
 
 [node name="CreateCharacter" parent="Popups" instance=ExtResource("1")]
 title = "Create Character"
+size = Vector2i(590, 172)
+max_size = Vector2i(1280, 720)
 
 [node name="CreateInventoryItem" parent="Popups" instance=ExtResource("6")]
 title = "Create Inventory item"
+size = Vector2i(545, 172)
+max_size = Vector2i(1280, 720)
 
 [node name="CreateDialog" parent="Popups" instance=ExtResource("2")]
 title = "Create Dialog tree"
+size = Vector2i(494, 172)
+max_size = Vector2i(1280, 720)
 
 [node name="CreateProp" parent="Popups" instance=ExtResource("5")]
 title = "Create prop"
+size = Vector2i(421, 202)
+max_size = Vector2i(1280, 720)
 
 [node name="CreateHotspot" parent="Popups" instance=ExtResource("14")]
 title = "Create hotspot"
+size = Vector2i(414, 172)
+max_size = Vector2i(1280, 720)
 
 [node name="CreateRegion" parent="Popups" instance=ExtResource("15")]
 title = "Create Region"
+size = Vector2i(405, 172)
+max_size = Vector2i(1280, 720)
 
 [node name="CreateWalkableArea" parent="Popups" instance=ExtResource("19")]
 title = "Create Walkable area"
+size = Vector2i(461, 172)
+max_size = Vector2i(1280, 720)
 
 [node name="DeleteConfirmation" parent="Popups" instance=ExtResource("17")]
 title = "Delete?"
+size = Vector2i(200, 720)
+max_size = Vector2i(1280, 720)
 
 [node name="Loading" parent="Popups" instance=ExtResource("16")]
 title = "Loading...."
+size = Vector2i(320, 180)
+min_size = Vector2i(320, 180)
+max_size = Vector2i(1280, 720)
 
 [node name="Setup" parent="Popups" instance=ExtResource("18")]
 title = "Setup"
+max_size = Vector2i(1280, 720)

--- a/addons/popochiu/editor/popups/create_character/create_character.gd
+++ b/addons/popochiu/editor/popups/create_character/create_character.gd
@@ -120,6 +120,9 @@ func _create() -> void:
 	new_character.description = _new_character_name.capitalize()
 	new_character.cursor = Constants.CURSOR_TYPE.TALK
 	
+	if PopochiuResources.get_settings().is_pixel_art_game:
+		new_character.get_node("Sprite2D").texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Save the character scene (.tscn)
 	var new_character_packed_scene: PackedScene = PackedScene.new()

--- a/addons/popochiu/editor/popups/create_inventory_item/create_inventory_item.gd
+++ b/addons/popochiu/editor/popups/create_inventory_item/create_inventory_item.gd
@@ -108,11 +108,14 @@ func _create() -> void:
 	# 	overwritten by that assignment.
 	new_item.set_script(load(_new_item_path + '.gd'))
 	
-	new_item.name = 'Item' + _new_item_name
+	new_item.name = 'Item' + _pascal_name
 	new_item.script_name = _pascal_name
 	new_item.description = _pascal_name.capitalize()
 	new_item.cursor = Constants.CURSOR_TYPE.USE
 	new_item.size_flags_vertical = new_item.SIZE_SHRINK_CENTER
+	
+	if PopochiuResources.get_settings().is_pixel_art_game:
+		new_item.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Save the item scene (.tscn)

--- a/addons/popochiu/editor/popups/create_prop/create_prop.gd
+++ b/addons/popochiu/editor/popups/create_prop/create_prop.gd
@@ -75,6 +75,9 @@ func _create() -> void:
 	prop.clickable = _interaction_checkbox.button_pressed
 	prop.cursor = Constants.CURSOR_TYPE.ACTIVE
 	
+	if PopochiuResources.get_settings().is_pixel_art_game:
+		prop.get_node("Sprite2D").texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	
 	if _new_prop_name in ['bg', 'background']:
 		prop.baseline =\
 		-ProjectSettings.get_setting(PopochiuResources.DISPLAY_HEIGHT) / 2.0

--- a/addons/popochiu/editor/popups/setup/setup.gd
+++ b/addons/popochiu/editor/popups/setup/setup.gd
@@ -125,6 +125,9 @@ func _update_project_settings() -> void:
 		int(_test_height.value)
 	)
 	
+	var settings := PopochiuResources.get_settings()
+	settings.is_pixel_art_game = false
+	
 	match _game_type.selected:
 		1:
 			ProjectSettings.set_setting(PopochiuResources.STRETCH_MODE, 'canvas_items')
@@ -132,6 +135,10 @@ func _update_project_settings() -> void:
 		2:
 			ProjectSettings.set_setting(PopochiuResources.STRETCH_MODE, 'canvas_items')
 			ProjectSettings.set_setting(PopochiuResources.STRETCH_ASPECT, 'keep')
+			
+			settings.is_pixel_art_game = true
+	
+	PopochiuResources.save_settings(settings)
 	
 	assert(\
 		ProjectSettings.save() == OK,\

--- a/addons/popochiu/engine/audio_manager/audio_cue.gd
+++ b/addons/popochiu/engine/audio_manager/audio_cue.gd
@@ -93,9 +93,16 @@ func set_loop(value: bool) -> void:
 		'AudioStreamOggVorbis', 'AudioStreamMP3':
 			audio.loop = value
 		'AudioStreamWAV':
-			(audio as AudioStreamWAV).loop_mode =\
-			AudioStreamWAV.LOOP_FORWARD if value\
-			else AudioStreamWAV.LOOP_DISABLED
+			if (audio as AudioStreamWAV).get_loop_end() == 0 && value:
+				PopochiuUtils.print_warning(
+					"[b]%s[/b]" % resource_name +\
+					" does not have the correct metadata to loop, please check" +\
+					" AudioStreamWAV documentation"
+				)
+			else:
+				(audio as AudioStreamWAV).loop_mode =\
+				AudioStreamWAV.LOOP_FORWARD if value\
+				else AudioStreamWAV.LOOP_DISABLED
 	
 	notify_property_list_changed()
 

--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -25,8 +25,30 @@ func _ready():
 
 
 func _process(delta):
-	$AnimatedSprite2D.position = $AnimatedSprite2D.get_global_mouse_position()
-	$Sprite2D.position = $AnimatedSprite2D.get_global_mouse_position()
+	var texture_size := ($AnimatedSprite2D.sprite_frames.get_frame_texture(
+		$AnimatedSprite2D.animation,
+		$AnimatedSprite2D.frame
+	) as Texture2D).get_size()
+	
+	var mouse_position: Vector2 = $AnimatedSprite2D.get_global_mouse_position()
+	
+	if E.settings.is_pixel_perfect:
+		# Thanks to @whyshchuck
+		$AnimatedSprite2D.position = Vector2i(mouse_position)
+		$Sprite2D.position = Vector2i(mouse_position)
+	else:
+		$AnimatedSprite2D.position = mouse_position
+		$Sprite2D.position = mouse_position
+	
+	if $AnimatedSprite2D.position.x < 1.0:
+		$AnimatedSprite2D.position.x = 1.0
+	elif $AnimatedSprite2D.position.x > E.width - 2.0:
+		$AnimatedSprite2D.position.x = E.width - 2.0
+	
+	if $AnimatedSprite2D.position.y < 1.0:
+		$AnimatedSprite2D.position.y = 1.0
+	elif $AnimatedSprite2D.position.y > E.height - 2.0:
+		$AnimatedSprite2D.position.y = E.height - 2.0
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -17,6 +17,7 @@ signal move_ended
 @export var voices := []:
 	set = set_voices # (Array, Dictionary)
 @export var follow_player := false
+@export var follow_player_offset := Vector2(20,0)
 @export var walk_speed := 200.0
 @export var can_move := true
 @export var ignore_walkable_areas := false

--- a/addons/popochiu/engine/objects/character/popochiu_character.tscn
+++ b/addons/popochiu/engine/objects/character/popochiu_character.tscn
@@ -4,17 +4,16 @@
 
 [node name="Character" type="Area2D"]
 script = ExtResource("1_2xmr4")
+popochiu_placeholder = null
 
 [node name="InteractionPolygon" type="CollisionPolygon2D" parent="."]
 polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
 [node name="BaselineHelper" type="Line2D" parent="."]
-visible = false
 points = PackedVector2Array(-10000, 0, 10000, 0)
 width = 1.0
 
 [node name="WalkToHelper" type="Marker2D" parent="."]
-visible = false
 
 [node name="ColorRect" type="ColorRect" parent="WalkToHelper"]
 offset_left = -2.5
@@ -26,7 +25,5 @@ color = Color(0, 1, 1, 1)
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-texture_filter = 1
 
 [node name="DialogPos" type="Marker2D" parent="."]
-visible = false

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -90,7 +90,7 @@ func queue_add_as_active(animate := true) -> Callable:
 func add_as_active(animate := true) -> void:
 	await add(animate)
 	
-	I.set_active_item(self)
+	I.set_active_item(self, true)
 
 
 func queue_remove(animate := false) -> Callable:

--- a/addons/popochiu/engine/objects/popochiu_settings.gd
+++ b/addons/popochiu/engine/objects/popochiu_settings.gd
@@ -21,3 +21,4 @@ preload('res://addons/popochiu/engine/others/importer_defaults.gd')
 @export var fade_color: Color = Color.BLACK
 @export var scale_gui := true
 @export var max_dialog_options := 3
+@export var is_pixel_art_game := false

--- a/addons/popochiu/engine/objects/popochiu_settings.gd
+++ b/addons/popochiu/engine/objects/popochiu_settings.gd
@@ -22,3 +22,4 @@ preload('res://addons/popochiu/engine/others/importer_defaults.gd')
 @export var scale_gui := true
 @export var max_dialog_options := 3
 @export var is_pixel_art_game := false
+@export var is_pixel_perfect := false

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -10,7 +10,8 @@ signal linked_item_removed(node)
 signal linked_item_discarded(node)
 
 @export var texture: Texture2D : set = set_texture
-@export var frames := 1: set = set_frames # (int, 1, 100)
+@export var frames := 1 : set = set_frames
+@export var v_frames := 1 : set = set_v_frames
 @export var current_frame := 0: set = set_current_frame # (int, 0, 99)
 @export var link_to_item := ''
 
@@ -73,6 +74,11 @@ func set_texture(value: Texture2D) -> void:
 func set_frames(value: int) -> void:
 	frames = value
 	$Sprite2D.hframes = value
+
+
+func set_v_frames(value: int) -> void:
+	v_frames = value
+	$Sprite2D.vframes = value
 
 
 func set_current_frame(value: int) -> void:

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.tscn
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.tscn
@@ -19,4 +19,3 @@ offset_bottom = 2.5
 color = Color(0, 1, 1, 1)
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-texture_filter = 1

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -131,8 +131,20 @@ func add_character(chr: PopochiuCharacter) -> void:
 	chr.started_walk_to.connect(_update_navigation_path)
 	chr.stopped_walk.connect(_clear_navigation_path.bind(chr))
 	
+	if chr.follow_player:
+		C.player.started_walk_to.connect(_follow_player.bind(chr))
+
 	chr.idle()
 
+func _follow_player(
+	character: PopochiuCharacter, start_position: Vector2, end_position: Vector2, follower: PopochiuCharacter
+):
+	var follower_end_position
+	if end_position.x > follower.position.x:
+		follower_end_position = end_position - follower.follow_player_offset
+	else:
+		follower_end_position = end_position + follower.follow_player_offset
+	follower.walk_to(follower_end_position)
 
 func remove_character(chr: PopochiuCharacter) -> void:
 	$Characters.remove_child(chr)

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -120,7 +120,7 @@ func _ready() -> void:
 	
 	# Add inventory items checked start (ignore animations (3rd parameter))
 	for key in settings.items_on_start:
-		I.add_item(key, false)
+		I[key].add(false)
 	
 	set_process_input(false)
 	

--- a/addons/popochiu/plugin.cfg
+++ b/addons/popochiu/plugin.cfg
@@ -4,5 +4,5 @@ name="Popochiu"
 description="[en] Point n' click games engine for Godot.
 [es] Motor para crear juegos de aventura gráfica en Godot."
 author="carenalga (@mapedorr) \\(|:3)/"
-version="2.0.0-alpha_3"
+version="2.0-alpha_4"
 script="popochiu_plugin.gd"

--- a/popochiu/characters/goddiu/character_goddiu.tscn
+++ b/popochiu/characters/goddiu/character_goddiu.tscn
@@ -314,12 +314,10 @@ metadata/_popochiu_aseprite_config_ = {
 polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
 [node name="BaselineHelper" type="Line2D" parent="."]
-visible = false
 points = PackedVector2Array(-10000, 0, 10000, 0)
 width = 1.0
 
 [node name="WalkToHelper" type="Marker2D" parent="."]
-visible = false
 
 [node name="ColorRect" type="ColorRect" parent="WalkToHelper"]
 offset_left = -2.5
@@ -336,7 +334,6 @@ hframes = 3
 vframes = 2
 
 [node name="DialogPos" type="Marker2D" parent="."]
-visible = false
 position = Vector2(0, -45)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/release-notes/v2.0-alpha4.md
+++ b/release-notes/v2.0-alpha4.md
@@ -14,3 +14,7 @@
 - [Audio Cues: Checking "loop" renders sound silent](https://github.com/mapedorr/popochiu/issues/87)
 - Setting an inventory item as active with add_as_active makes the cursor take the appearance of the item.
 - Devs can select items to start with in the Main tab.
+
+## Others
+
+- Updated the maximum size of the plugin popups in an attempt to improve the UX of Mac users.

--- a/release-notes/v2.0-alpha4.md
+++ b/release-notes/v2.0-alpha4.md
@@ -1,0 +1,16 @@
+# Popochiu 2.0 Alpha 4
+[![Godot v4.0.x](https://img.shields.io/badge/Godot-4.0.x-blue)](https://godotengine.org/download/archive/4.0.4-stable/) [![Godot v4.1.x](https://img.shields.io/badge/Godot-4.1.x-blue)](https://godotengine.org/download)
+
+## New features
+
+- Added is_pixel_art_game property to ProjectSettings. When selecting Pixel in Game type (setup popup) the default texture filter is set to TEXTURE_FILTER_NEAREST for props, characters and inventory items.
+- [NPC's follows the player](https://github.com/mapedorr/popochiu/pull/105) when the `follow_player` property is `true`.
+- Add `v_frames`` property to PopochiuProp.
+- Add settings option to set a pixel perfect game. When `true`, the cursor moves in whole pixels (thanks to @Whyshchuck ).
+- The cursor sprite doesn't leave the viewport when the mouse pointer leaves the game window.
+
+## Fixes
+
+- [Audio Cues: Checking "loop" renders sound silent](https://github.com/mapedorr/popochiu/issues/87)
+- Setting an inventory item as active with add_as_active makes the cursor take the appearance of the item.
+- Devs can select items to start with in the Main tab.


### PR DESCRIPTION
# New features

- Added `is_pixel_art_game` property to ProjectSettings. When selecting Pixel in Game type (setup popup) the default texture filter is set to TEXTURE_FILTER_NEAREST for props, characters and inventory items.
- #105 
- Add `v_frames`` property to PopochiuProp.
- Add settings option to set a pixel perfect game. When `true`, the cursor moves in whole pixels (thanks to @Whyshchuck ).
- The cursor sprite doesn't leave the viewport when the mouse pointer leaves the game window.

# Fixes

- #87 
- Setting an inventory item as active with `add_as_active` makes the cursor take the appearance of the item.
- Devs can select items to start with in the Main tab.

## Others

- Updated the maximum size of the plugin popups in an attempt to improve the UX of Mac users.