### PR TITLE
Fix missing images when importing room from Aseprite

### DIFF
--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_inspector_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_inspector_dock.gd
@@ -293,14 +293,26 @@ func _get_tags_from_source() -> Array:
 	return tags_list
 
 
-func _show_message(message: String, title: String = ""):
+func _show_message(
+	message: String, title: String = "", object: Object = null, method := ""
+):
 	var _warning_dialog = AcceptDialog.new()
 	get_parent().add_child(_warning_dialog)
 	if title != "":
 		_warning_dialog.title = title
 	_warning_dialog.dialog_text = message
+	_warning_dialog.popup_window = true
 	_warning_dialog.popup_centered()
-	_warning_dialog.connect("close_requested", Callable(_warning_dialog, "queue_free"))
+	
+	var callback := Callable(_warning_dialog, "queue_free")
+	
+	if is_instance_valid(object) and not method.is_empty():
+		callback = func():
+			_warning_dialog.queue_free()
+			object.call(method)
+	
+	_warning_dialog.confirmed.connect(callback)
+	_warning_dialog.close_requested.connect(callback)
 
 
 func _show_confirmation(message: String, title: String = ""):

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_inspector_dock_room.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_inspector_dock_room.gd
@@ -69,7 +69,13 @@ func _on_import_pressed():
 		_show_message("Some errors occurred. Please check output panel.", "Warning!")
 	else:
 		await get_tree().create_timer(0.1).timeout
-		_show_message("%d animation tags processed." % [_tags_cache.size()], "Done!")
+		# Once the popup is closed, call _clean_props()
+		_show_message(
+			"%d animation tags processed." % [_tags_cache.size()],
+			"Done!",
+			self,
+			"_clean_props"
+		)
 
 
 func _customize_tag_ui(tag_row: AnimationTagRow):
@@ -94,3 +100,16 @@ func _save_prop(prop: PopochiuProp):
 		)
 		return ResultCodes.ERR_CANT_SAVE_OBJ_SCENE
 	return ResultCodes.SUCCESS
+
+
+## Removes the script in all the created props so the properties (basically their
+## texture) is not overwritten by the room's .tscn file. Then the scene is saved
+## and reloaded so the nodes in the tree doesn't appear as Area2D but as the
+## corresponding ones: PopochiuProp.
+func _clean_props() -> void:
+	for prop in _root_node.get_node("Props").get_children():
+		prop.set_script(null)
+		prop.remove_meta("ANIM_NAME")
+
+	main_dock.ei.save_scene()
+	main_dock.ei.reload_scene_from_path(_root_node.scene_file_path)

--- a/popochiu/rooms/house/room_house.tscn
+++ b/popochiu/rooms/house/room_house.tscn
@@ -18,6 +18,7 @@ outlines = Array[PackedVector2Array]([PackedVector2Array(-88, 16, -40, 7, 81, 12
 
 [node name="RoomHouse" type="Node2D"]
 script = ExtResource("1_5s51l")
+popochiu_placeholder = null
 
 [node name="WalkableAreas" type="Node2D" parent="."]
 
@@ -43,6 +44,7 @@ texture = ExtResource("7_ys5mq")
 walk_to_point = Vector2(26, -2)
 
 [node name="InteractionPolygon" type="CollisionPolygon2D" parent="Props/ToyCar"]
+visible = false
 polygon = PackedVector2Array(-8, 1, -7, -4, 0, -5, 7, -2, 7, 3, 2, 5, -6, 4)
 
 [node name="Hotspots" type="Node2D" parent="."]


### PR DESCRIPTION
When props are created (this applies to hotspots, regions and walkable areas too) Godot includes a reference to the object's script in its `.tscn` file, which overwrites the properties of the object making its texture not visible until one executes what @stickgrinder called the "dance of the death": You have to close the room scene, open it again, save, close and reopen it again in order to be able to see the images of the props correctly.

The fix consists on removing the script from the props in the scene once they are created, so the texture and other properties are not overwritten by the room's `.tscn` file.