### PR TITLE
refs 114: character sprite scaling regions

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -26,6 +26,9 @@ var last_room := ''
 var anim_suffix := ''
 var is_moving := false
 var emotion := ''
+var on_scaling_region: Dictionary = {}
+var default_walk_speed: int
+var default_scale: Vector2
 
 var _looking_dir: int = Looking.DOWN
 
@@ -35,7 +38,8 @@ var _looking_dir: int = Looking.DOWN
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
 func _ready():
 	super()
-	
+	default_walk_speed = walk_speed
+	default_scale = Vector2(scale)
 	if not Engine.is_editor_hint():
 		set_process(follow_player)
 	else:

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -41,8 +41,15 @@ func _update_scaling_region(chr: PopochiuCharacter) -> void:
 		'region_description': self.description,
 		'scale_top': self.scale_top, 
 		'scale_bottom': self.scale_bottom,  
-		'polygon_top_y': polygon_y_array.min()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
-		'polygon_bottom_y': polygon_y_array.max()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
+		'polygon_top_y': (
+			polygon_y_array.min()+self.position.y+get_node("InteractionPolygon").position.y 
+			if self.position 
+			else ''
+			),
+		'polygon_bottom_y': (
+			polygon_y_array.max()+self.position.y+get_node("InteractionPolygon").position.y 
+			if self.position 
+			else ''),
 
 		}
 

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -11,10 +11,9 @@ extends Area2D
 # TODO: If walkable is false, characters should not be able to walk through this.
 #export var walkable := true
 @export var tint := Color.WHITE
-# TODO: Make the scale of the character change depending checked where it is placed in
-# the area.
-#export var scale_top := 1.0
-#export var scale_bottom := 1.0
+@export var scaling :bool = false
+@export var scale_top :float = 1.0
+@export var scale_bottom :float = 1.0
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
@@ -33,12 +32,35 @@ func _on_character_entered(chr: PopochiuCharacter) -> void:
 func _on_character_exited(chr: PopochiuCharacter) -> void:
 	pass
 
+func _update_scaling_region(chr: PopochiuCharacter) -> void:
+	var polygon_y_array = []
+	for x in get_node("InteractionPolygon").get_polygon():
+		polygon_y_array.append(x.y)
+
+	chr.on_scaling_region= {
+		'region_description': self.description,
+		'scale_top': self.scale_top, 
+		'scale_bottom': self.scale_bottom,  
+		'polygon_top_y': polygon_y_array.min()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
+		'polygon_bottom_y': polygon_y_array.max()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
+
+		}
+
+
+func _clear_scaling_region(chr: PopochiuCharacter) -> void:
+	if chr.on_scaling_region and chr.on_scaling_region['region_description'] == self.description:
+		chr.on_scaling_region = {}
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
 func _check_area(area: PopochiuCharacter, entered: bool) -> void:
 	if area is PopochiuCharacter:
-		if entered: _on_character_entered(area)
-		else: _on_character_exited(area)
+		if entered:
+			_on_character_entered(area)
+			if scaling:
+				_update_scaling_region(area)
+		else:
+			_on_character_exited(area)
+			_clear_scaling_region(area)
 
 
 func _set_enabled(value: bool) -> void:

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -130,7 +130,7 @@ func add_character(chr: PopochiuCharacter) -> void:
 	#warning-ignore:return_value_discarded
 	chr.started_walk_to.connect(_update_navigation_path)
 	chr.stopped_walk.connect(_clear_navigation_path.bind(chr))
-	
+	update_characters_position(chr)
 	if chr.follow_player:
 		C.player.started_walk_to.connect(_follow_player.bind(chr))
 

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -287,6 +287,26 @@ func set_active_walkable_area(walkable_area_name: String) -> void:
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+
+func _update_character_scale(chr):
+	if chr.on_scaling_region:
+		var polygon_range = chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
+		var scale_range = chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
+
+		var position_from_the_top_of_region = chr.position.y-chr.on_scaling_region['polygon_top_y']
+
+		var scale_for_position = (
+			chr.on_scaling_region['scale_top']+(
+				scale_range/polygon_range*position_from_the_top_of_region
+		)
+		)
+		chr.scale.x = scale_for_position
+		chr.scale.y = scale_for_position
+		chr.walk_speed = chr.default_walk_speed/chr.default_scale.x*scale_for_position
+	else:
+		chr.scale = chr.default_scale
+		chr.walk_speed = chr.default_walk_speed
+
 func _move_along_path(distance: float, moving_character_data: Dictionary):
 	var last_point = moving_character_data.character.position
 
@@ -298,6 +318,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 			moving_character_data.character.position = last_point.lerp(
 				moving_character_data.path[0], distance / distance_between_points
 			)
+			_update_character_scale(moving_character_data.character)
 			return
 
 		distance -= distance_between_points
@@ -305,6 +326,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 		moving_character_data.path.remove_at(0)
 
 	moving_character_data.character.position = last_point
+	_update_character_scale(moving_character_data.character)
 	_clear_navigation_path(moving_character_data.character)
 
 

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -296,10 +296,16 @@ func set_active_walkable_area(walkable_area_name: String) -> void:
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
 func _update_character_scale(chr):
 	if chr.on_scaling_region:
-		var polygon_range = chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
-		var scale_range = chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
+		var polygon_range = (
+			chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
+			)
+		var scale_range = (
+			chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
+			)
 
-		var position_from_the_top_of_region = chr.position.y-chr.on_scaling_region['polygon_top_y']
+		var position_from_the_top_of_region = (
+			chr.position.y-chr.on_scaling_region['polygon_top_y']
+			)
 
 		var scale_for_position = (
 			chr.on_scaling_region['scale_top']+(


### PR DESCRIPTION
Every region in the room can be set as "scaling":

![image](https://github.com/mapedorr/popochiu/assets/34949896/31dda221-41cd-49fe-9cad-699b619d1a60)

than you can set scale for the top and bottom of the region (meant as the highest and lowest position of region's polygon

every character stores info about scaling region he's standing on, in form of dictionary.
than game calculates scale proportionate (linear) for the character's opsition.

Warnings:
- needs additional changes to be merged with my anti-glide (i have it ready, but i can't pull request it in reasonable way until it's merged).
- acts a bit wirdeley in one edge case:
    if there is drastic change of scale at the top of the region, character enters and exits region multiple times.
    to avoid it, collishion shape for character's have to be reduced to [0,0, 0,0, 0,0, 0,0]

For further infos #114
    

