### PR TITLE
Fix issue when exporting project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Addons other than Popochiu
 # (we use some for development)
-addons/**
-!addons/popochiu/**
+# addons/**
+# !addons/popochiu/**
 
 # Godot-specific ignores
 .import/

--- a/addons/popochiu/editor/helpers/popochiu_editor_helper.gd
+++ b/addons/popochiu/editor/helpers/popochiu_editor_helper.gd
@@ -1,0 +1,11 @@
+@tool
+class_name PopochiuEditorHelper
+extends Resource
+## Utils class for Editor related things.
+
+static var ei: EditorInterface = null
+static var undo_redo: EditorUndoRedoManager = null
+
+static func select_node(node: Node) -> void:
+	ei.get_selection().clear()
+	ei.get_selection().add_node(node)

--- a/addons/popochiu/editor/inspector/walkable_area_inspector_plugin.gd
+++ b/addons/popochiu/editor/inspector/walkable_area_inspector_plugin.gd
@@ -46,7 +46,7 @@ func _parse_walkable_area(object: Object) -> void:
 func _find_polygon_instance(object: Object) -> void:
 	if not object is PopochiuWalkableArea: return
 	var children = object.get_children()
-	PopochiuUtils.select_node(children[0])
+	PopochiuEditorHelper.select_node(children[0])
 
 
 func _parse_navigation_polygon_instance(object: Object) -> void:
@@ -78,4 +78,4 @@ func _parse_navigation_polygon_instance(object: Object) -> void:
 
 func _back_to_walkable_area(object: Object) -> void:
 	if not object.get_parent() is PopochiuWalkableArea: return
-	PopochiuUtils.select_node(object.get_parent())
+	PopochiuEditorHelper.select_node(object.get_parent())

--- a/addons/popochiu/editor/main_dock/object_row/popochiu_object_row.gd
+++ b/addons/popochiu/editor/main_dock/object_row/popochiu_object_row.gd
@@ -325,7 +325,7 @@ func _menu_item_pressed(id: int) -> void:
 			prop.set_script(script)
 			
 			main_dock.ei.save_scene()
-			PopochiuUtils.select_node(prop)
+			PopochiuEditorHelper.select_node(prop)
 			main_dock.ei.select_file(script_path)
 			
 			# Update this row properties and state

--- a/addons/popochiu/editor/main_dock/tab_room.gd
+++ b/addons/popochiu/editor/main_dock/tab_room.gd
@@ -237,7 +237,7 @@ func _select_in_tree(por: PopochiuObjectRow) -> void:
 		var node := opened_room.get_node('%s/%s'\
 		% [_types[por.type].parent, por.node_path])
 		
-		PopochiuUtils.select_node(node)
+		PopochiuEditorHelper.select_node(node)
 	
 	_last_selected = por
 
@@ -336,7 +336,7 @@ func _on_character_seleced(id: int) -> void:
 	instance.owner = opened_room
 	
 	main_dock.ei.save_scene()
-	PopochiuUtils.select_node(instance)
+	PopochiuEditorHelper.select_node(instance)
 
 
 func _create_row_in_dock(type_id: int, child: Node) -> PopochiuObjectRow:

--- a/addons/popochiu/editor/popups/create_hotspot/create_hotspot.gd
+++ b/addons/popochiu/editor/popups/create_hotspot/create_hotspot.gd
@@ -83,7 +83,7 @@ func _create() -> void:
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Abrir las propiedades del hotspot creado en el Inspector
 	await get_tree().create_timer(0.1).timeout
-	PopochiuUtils.select_node(hotspot)
+	PopochiuEditorHelper.select_node(hotspot)
 	
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Fin

--- a/addons/popochiu/editor/popups/create_prop/create_prop.gd
+++ b/addons/popochiu/editor/popups/create_prop/create_prop.gd
@@ -120,7 +120,7 @@ func _create() -> void:
 	# Abrir las propiedades de la prop creada en el Inspector
 	_main_dock.fs.scan()
 	await get_tree().create_timer(0.1).timeout
-	PopochiuUtils.select_node(prop_instance)
+	PopochiuEditorHelper.select_node(prop_instance)
 	_main_dock.ei.select_file(_new_prop_path + '.tscn')
 	
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓

--- a/addons/popochiu/editor/popups/create_region/create_region.gd
+++ b/addons/popochiu/editor/popups/create_region/create_region.gd
@@ -80,7 +80,7 @@ func _create() -> void:
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Abrir las propiedades de la región creada en el Inspector
 	await get_tree().create_timer(0.1).timeout
-	PopochiuUtils.select_node(region)
+	PopochiuEditorHelper.select_node(region)
 	
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Fin

--- a/addons/popochiu/editor/popups/create_walkable_area/create_walkable_area.gd
+++ b/addons/popochiu/editor/popups/create_walkable_area/create_walkable_area.gd
@@ -74,6 +74,7 @@ func _create() -> void:
 	perimeter.name = 'Perimeter'
 	
 	var polygon := NavigationPolygon.new()
+	polygon.agent_radius = 0
 	polygon.add_outline(PackedVector2Array([
 		Vector2(-10, -10), Vector2(10, -10), Vector2(10, 10), Vector2(-10, 10)
 	]))

--- a/addons/popochiu/editor/popups/create_walkable_area/create_walkable_area.gd
+++ b/addons/popochiu/editor/popups/create_walkable_area/create_walkable_area.gd
@@ -99,7 +99,7 @@ func _create() -> void:
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Abrir las propiedades de la walkable area creada en el Inspector
 	await get_tree().create_timer(0.1).timeout
-	PopochiuUtils.select_node(walkable_area)
+	PopochiuEditorHelper.select_node(walkable_area)
 	
 	# ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 	# Fin

--- a/addons/popochiu/engine/objects/graphic_interface/display_box/display_box.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/display_box/display_box.gd
@@ -2,8 +2,6 @@ extends RichTextLabel
 # Show a text in the form of GUI. Can be used to show game (or narrator)
 # messages.
 # ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-# warning-ignore-all:unused_signal
-# warning-ignore-all:return_value_discarded
 
 signal shown
 
@@ -44,9 +42,11 @@ func _show_box(msg := '') -> void:
 	rt.append_text(msg)
 	lbl.text = rt.text
 	add_child(lbl)
-	var size := lbl.size
-	if size.x > get_meta(DFLT_SIZE).x:
-		size.x = get_meta(DFLT_SIZE).x - 16.0
+	
+	var lbl_size := lbl.size
+	if lbl_size.x > get_meta(DFLT_SIZE).x:
+		lbl_size.x = get_meta(DFLT_SIZE).x - 16.0
+	
 	lbl.free()
 	rt.free()
 	# ===================================== Calculate the width of the node ====

--- a/addons/popochiu/engine/objects/graphic_interface/graphic_interface.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/graphic_interface.tscn
@@ -89,6 +89,7 @@ theme_override_styles/disabled = SubResource("StyleBoxEmpty_pcw4k")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_scpl3")
 
 [node name="History" parent="." instance=ExtResource("7")]
+visible = false
 
 [node name="SaveLoad" parent="." instance=ExtResource("8")]
 visible = false

--- a/addons/popochiu/engine/others/popochiu_utils.gd
+++ b/addons/popochiu/engine/others/popochiu_utils.gd
@@ -1,16 +1,16 @@
-# Utility functions for Popochiu.
 @tool
-extends Node
 class_name PopochiuUtils
+extends Node
+## Utility functions for Popochiu.
 
-static var ei: EditorInterface = null
 
-
+## Used by the graphic interface to get the position of a `node` in the scene
+## in the transform space of the CanvasLayer where it is is rendered.
 static func get_screen_coords_for(node: Node) -> Vector2:
 	return node.get_viewport().canvas_transform * node.get_global_position()
 
 
-# Gets a random element from an Array
+## Gets a random element from an Array.
 static func get_random_array_element(arr: Array):
 	randomize()
 	var idx := randi() % arr.size()
@@ -18,7 +18,7 @@ static func get_random_array_element(arr: Array):
 	return arr[idx]
 
 
-# Gets a random index from an Array
+## Gets a random index from an Array.
 static func get_random_array_idx(arr: Array) -> int:
 	randomize()
 	var idx := randi() % arr.size()
@@ -26,24 +26,25 @@ static func get_random_array_idx(arr: Array) -> int:
 	return idx
 
 
+## Compares the name of two files `a` and `b` to check which one comes first in
+## alphabetical order.
 static func sort_by_file_name(a: String, b: String) -> bool:
 	if a.get_file() < b.get_file():
 		return true
 	return false
 
 
+## Overrides the font with `font_name` in a Control `node` with the Font received
+## in `font`.
 static func override_font(node: Control, font_name: String, font: Font) -> void:
 	node.add_theme_font_override(font_name, font)
 
 
-static func select_node(node: Node) -> void:
-	ei.get_selection().clear()
-	ei.get_selection().add_node(node)
-
-
+## Prints the text in `msg` with the error style for Popochiu.
 static func print_error(msg: String) -> void:
 	print_rich("[bgcolor=c46c71][color=ffffff][b][Popochiu][/b] %s[/color][/bgcolor]" % msg)
 
 
+## Prints the text in `msg` with the warning style for Popochiu.
 static func print_warning(msg: String) -> void:
 	print_rich("[bgcolor=edf171][color=4a4a4a][b][Popochiu][/b] %s[/color][/bgcolor]" % msg)

--- a/addons/popochiu/plugin.cfg
+++ b/addons/popochiu/plugin.cfg
@@ -4,5 +4,5 @@ name="Popochiu"
 description="[en] Point n' click games engine for Godot.
 [es] Motor para crear juegos de aventura gráfica en Godot."
 author="carenalga (@mapedorr) \\(|:3)/"
-version="2.0-alpha_5"
+version="2.0-alpha_6"
 script="popochiu_plugin.gd"

--- a/addons/popochiu/plugin.cfg
+++ b/addons/popochiu/plugin.cfg
@@ -4,5 +4,5 @@ name="Popochiu"
 description="[en] Point n' click games engine for Godot.
 [es] Motor para crear juegos de aventura gráfica en Godot."
 author="carenalga (@mapedorr) \\(|:3)/"
-version="2.0-alpha_6"
+version="2.0-beta_1"
 script="popochiu_plugin.gd"

--- a/addons/popochiu/popochiu_export_plugin.gd
+++ b/addons/popochiu/popochiu_export_plugin.gd
@@ -9,16 +9,17 @@ func _export_begin(features: PackedStringArray, is_debug: bool, path: String, fl
 	
 	file.close()
 
-# Logic for Aseprite Importer
-# This code removes importer's metadata from nodes before exporting them
-# Thanks to Vinicius Gerevini and his Aseprite Wizard plugin for that!
-# TODO: may be moved to another file so we keep things separated
+
+## Logic for Aseprite Importer
+## This code removes importer's metadata from nodes before exporting them
+## Thanks to Vinicius Gerevini and his Aseprite Wizard plugin for that!
+## TODO: may be moved to another file so we keep things separated
 func _export_file(path: String, type: String, features: PackedStringArray) -> void:
 	if type != "PackedScene": return
 
 	var scene : PackedScene =  ResourceLoader.load(path, type, 0)
 	var scene_changed := false
-	var root_node: Node = scene.instance(PackedScene.GEN_EDIT_STATE_INSTANCE)
+	var root_node: Node = scene.instantiate(PackedScene.GEN_EDIT_STATE_INSTANCE)
 	var nodes := [root_node]
 
 	#remove metadata from scene
@@ -44,6 +45,7 @@ func _export_file(path: String, type: String, features: PackedStringArray) -> vo
 
 	root_node.free()
 
+
 func _remove_meta(node:Node, path: String) -> bool:
 	if node.has_meta(LOCAL_OBJ_CONFIG.LOCAL_OBJ_CONFIG_META_NAME):
 		node.remove_meta(LOCAL_OBJ_CONFIG.LOCAL_OBJ_CONFIG_META_NAME)
@@ -51,6 +53,7 @@ func _remove_meta(node:Node, path: String) -> bool:
 		return true
 
 	return false
+
 
 func _get_scene_content(path:String, scene:PackedScene) -> PackedByteArray:
 	var tmp_path = OS.get_cache_dir()  + "tmp_scene." + path.get_extension()

--- a/addons/popochiu/popochiu_plugin.gd
+++ b/addons/popochiu/popochiu_plugin.gd
@@ -94,6 +94,7 @@ func _enter_tree() -> void:
 	main_dock.fs = _editor_file_system
 	main_dock.focus_mode = Control.FOCUS_ALL
 	PopochiuEditorHelper.ei = _editor_interface
+	PopochiuEditorHelper.undo_redo = get_undo_redo()
 	
 	add_control_to_dock(DOCK_SLOT_RIGHT_BL, main_dock)
 	

--- a/addons/popochiu/popochiu_plugin.gd
+++ b/addons/popochiu/popochiu_plugin.gd
@@ -1,8 +1,8 @@
-# Plugin setup.
-# 
-# Some icons that might be useful: godot\editor\editor_themes.cpp
 @tool
 extends EditorPlugin
+## Plugin setup.
+## 
+## Some icons that might be useful: godot\editor\editor_themes.cpp
 
 const ES :=\
 "[es] Estás usando Popochiu, un plugin para crear juegos point n' click"
@@ -25,7 +25,6 @@ var _shown_helpers := []
 var _export_plugin: EditorExportPlugin = null
 var _inspector_plugins := []
 var _selected_node: Node = null
-var _vsep := VSeparator.new()
 var _btn_baseline := Button.new()
 var _btn_walk_to := Button.new()
 var _types_helper: Resource = null
@@ -94,7 +93,7 @@ func _enter_tree() -> void:
 	main_dock.ei = _editor_interface
 	main_dock.fs = _editor_file_system
 	main_dock.focus_mode = Control.FOCUS_ALL
-	PopochiuUtils.ei = _editor_interface
+	PopochiuEditorHelper.ei = _editor_interface
 	
 	add_control_to_dock(DOCK_SLOT_RIGHT_BL, main_dock)
 	
@@ -361,11 +360,9 @@ func _check_nodes() -> void:
 				_btn_baseline.set_pressed_no_signal(false)
 				_btn_walk_to.set_pressed_no_signal(false)
 			
-			_btn_baseline.show()
-			_btn_walk_to.show()
+			_btn_baseline.get_parent().show()
 		else:
-			_btn_baseline.hide()
-			_btn_walk_to.hide()
+			_btn_baseline.get_parent().hide()
 
 
 func _on_files_moved(old_file: String, new_file: String) -> void:
@@ -379,7 +376,6 @@ func _on_file_removed(file: String) -> void:
 
 
 func _create_container_buttons() -> void:
-	var panl := Panel.new()
 	var hbox := HBoxContainer.new()
 	
 	_btn_baseline.icon = preload('res://addons/popochiu/icons/baseline.png')
@@ -396,26 +392,20 @@ func _create_container_buttons() -> void:
 	_btn_walk_to.add_theme_stylebox_override('hover', _tool_btn_stylebox)
 	_btn_walk_to.pressed.connect(_select_walk_to)
 	
-	hbox.add_child(_vsep)
 	hbox.add_child(_btn_baseline)
 	hbox.add_child(_btn_walk_to)
 	
-	panl.add_child(hbox)
-	
 	add_control_to_container(
 		EditorPlugin.CONTAINER_CANVAS_EDITOR_MENU,
-		panl
+		hbox
 	)
 	
-	_vsep.hide()
-	_btn_baseline.hide()
-	_btn_walk_to.hide()
+	hbox.hide()
 
 
 func _select_walk_to() -> void:
 	_btn_walk_to.set_pressed_no_signal(true)
 	_btn_baseline.set_pressed_no_signal(false)
-	_vsep.hide()
 	
 	_editor_interface.get_selection().clear()
 	
@@ -433,7 +423,6 @@ func _select_walk_to() -> void:
 func _select_baseline() -> void:
 	_btn_baseline.set_pressed_no_signal(true)
 	_btn_walk_to.set_pressed_no_signal(false)
-	_vsep.show()
 	
 	_editor_interface.get_selection().clear()
 	

--- a/project.godot
+++ b/project.godot
@@ -13,7 +13,6 @@ config_version=5
 config/name="popochiu 2.0"
 config/description="Make 2D point n' click games with a smooth workflow (like in Adventure Game Studio or PowerQuest)."
 config/tags=PackedStringArray("4.2.x")
-run/main_scene="res://popochiu/rooms/house/room_house.tscn"
 config/features=PackedStringArray("4.2")
 config/icon="res://icon_v2.png"
 config/windows_native_icon="res://popochiu_v2.ico"

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="popochiu 2.0"
 config/description="Make 2D point n' click games with a smooth workflow (like in Adventure Game Studio or PowerQuest)."
-config/tags=PackedStringArray("4.1.x")
+config/tags=PackedStringArray("4.2.x")
 run/main_scene="res://popochiu/rooms/house/room_house.tscn"
 config/features=PackedStringArray("4.2")
 config/icon="res://icon_v2.png"

--- a/project.godot
+++ b/project.godot
@@ -14,7 +14,7 @@ config/name="popochiu 2.0"
 config/description="Make 2D point n' click games with a smooth workflow (like in Adventure Game Studio or PowerQuest)."
 config/tags=PackedStringArray("4.1.x")
 run/main_scene="res://popochiu/rooms/house/room_house.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon_v2.png"
 config/windows_native_icon="res://popochiu_v2.ico"
 


### PR DESCRIPTION
This was because PopochiuUtils had a variable of the EditorInterface.

- Walkable area's NavigationRegion automatically bakes its polygon with each edition.
- Fix bug of `size` property access in **display_box.gd**.
- Update version name to beta_1 and remove the scene definied in `run/main_scene` in the project settings.