### PR TITLE
Refs 114: character sprite scaling regions update

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -26,6 +26,9 @@ var last_room := ''
 var anim_suffix := ''
 var is_moving := false
 var emotion := ''
+var on_scaling_region: Dictionary = {}
+var default_walk_speed: int
+var default_scale: Vector2
 
 var _looking_dir: int = Looking.DOWN
 
@@ -35,7 +38,8 @@ var _looking_dir: int = Looking.DOWN
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
 func _ready():
 	super()
-	
+	default_walk_speed = walk_speed
+	default_scale = Vector2(scale)
 	if not Engine.is_editor_hint():
 		set_process(follow_player)
 	else:

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -41,8 +41,15 @@ func _update_scaling_region(chr: PopochiuCharacter) -> void:
 		'region_description': self.description,
 		'scale_top': self.scale_top, 
 		'scale_bottom': self.scale_bottom,  
-		'polygon_top_y': polygon_y_array.min()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
-		'polygon_bottom_y': polygon_y_array.max()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
+		'polygon_top_y': (
+			polygon_y_array.min()+self.position.y+get_node("InteractionPolygon").position.y 
+			if self.position 
+			else ''
+			),
+		'polygon_bottom_y': (
+			polygon_y_array.max()+self.position.y+get_node("InteractionPolygon").position.y 
+			if self.position 
+			else ''),
 
 		}
 

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -67,9 +67,11 @@ func _check_area(area: PopochiuCharacter, entered: bool) -> void:
 			_on_character_entered(area)
 			if scaling:
 				_update_scaling_region(area)
+				E.current_room.update_character_scale(area)
 		else:
 			_on_character_exited(area)
 			_clear_scaling_region(area)
+			E.current_room.update_character_scale(area)
 
 
 func _set_enabled(value: bool) -> void:

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -11,10 +11,9 @@ extends Area2D
 # TODO: If walkable is false, characters should not be able to walk through this.
 #export var walkable := true
 @export var tint := Color.WHITE
-# TODO: Make the scale of the character change depending checked where it is placed in
-# the area.
-#export var scale_top := 1.0
-#export var scale_bottom := 1.0
+@export var scaling :bool = false
+@export var scale_top :float = 1.0
+@export var scale_bottom :float = 1.0
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
@@ -33,12 +32,35 @@ func _on_character_entered(chr: PopochiuCharacter) -> void:
 func _on_character_exited(chr: PopochiuCharacter) -> void:
 	pass
 
+func _update_scaling_region(chr: PopochiuCharacter) -> void:
+	var polygon_y_array = []
+	for x in get_node("InteractionPolygon").get_polygon():
+		polygon_y_array.append(x.y)
+
+	chr.on_scaling_region= {
+		'region_description': self.description,
+		'scale_top': self.scale_top, 
+		'scale_bottom': self.scale_bottom,  
+		'polygon_top_y': polygon_y_array.min()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
+		'polygon_bottom_y': polygon_y_array.max()+self.position.y+get_node("InteractionPolygon").position.y if self.position else '',
+
+		}
+
+
+func _clear_scaling_region(chr: PopochiuCharacter) -> void:
+	if chr.on_scaling_region and chr.on_scaling_region['region_description'] == self.description:
+		chr.on_scaling_region = {}
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
 func _check_area(area: PopochiuCharacter, entered: bool) -> void:
 	if area is PopochiuCharacter:
-		if entered: _on_character_entered(area)
-		else: _on_character_exited(area)
+		if entered:
+			_on_character_entered(area)
+			if scaling:
+				_update_scaling_region(area)
+		else:
+			_on_character_exited(area)
+			_clear_scaling_region(area)
 
 
 func _set_enabled(value: bool) -> void:

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -40,7 +40,9 @@ func _update_scaling_region(chr: PopochiuCharacter) -> void:
 	chr.on_scaling_region= {
 		'region_description': self.description,
 		'scale_top': self.scale_top, 
-		'scale_bottom': self.scale_bottom,  
+		'scale_bottom': self.scale_bottom,
+		'scale_max': [self.scale_top, self.scale_bottom].max(),
+		'scale_min': [self.scale_top, self.scale_bottom].min(),
 		'polygon_top_y': (
 			polygon_y_array.min()+self.position.y+get_node("InteractionPolygon").position.y 
 			if self.position 

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -130,7 +130,7 @@ func add_character(chr: PopochiuCharacter) -> void:
 	#warning-ignore:return_value_discarded
 	chr.started_walk_to.connect(_update_navigation_path)
 	chr.stopped_walk.connect(_clear_navigation_path.bind(chr))
-	
+	update_characters_position(chr)
 	if chr.follow_player:
 		C.player.started_walk_to.connect(_follow_player.bind(chr))
 

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -200,8 +200,14 @@ func update_character_scale(chr):
 				scale_range/polygon_range*position_from_the_top_of_region
 		)
 		)
-		chr.scale.x = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
-		chr.scale.y = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
+		chr.scale.x = [
+			[scale_for_position, chr.on_scaling_region['scale_min']].max(), 
+			chr.on_scaling_region['scale_max']
+		].min()
+		chr.scale.y = [
+			[scale_for_position, chr.on_scaling_region['scale_min']].max(), 
+			chr.on_scaling_region['scale_max']
+		].min()
 		chr.walk_speed = chr.default_walk_speed/chr.default_scale.x*scale_for_position
 	else:
 		chr.scale = chr.default_scale

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -287,6 +287,26 @@ func set_active_walkable_area(walkable_area_name: String) -> void:
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+
+func _update_character_scale(chr):
+	if chr.on_scaling_region:
+		var polygon_range = chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
+		var scale_range = chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
+
+		var position_from_the_top_of_region = chr.position.y-chr.on_scaling_region['polygon_top_y']
+
+		var scale_for_position = (
+			chr.on_scaling_region['scale_top']+(
+				scale_range/polygon_range*position_from_the_top_of_region
+		)
+		)
+		chr.scale.x = scale_for_position
+		chr.scale.y = scale_for_position
+		chr.walk_speed = chr.default_walk_speed/chr.default_scale.x*scale_for_position
+	else:
+		chr.scale = chr.default_scale
+		chr.walk_speed = chr.default_walk_speed
+
 func _move_along_path(distance: float, moving_character_data: Dictionary):
 	var last_point = moving_character_data.character.position
 
@@ -298,6 +318,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 			moving_character_data.character.position = last_point.lerp(
 				moving_character_data.path[0], distance / distance_between_points
 			)
+			_update_character_scale(moving_character_data.character)
 			return
 
 		distance -= distance_between_points
@@ -305,6 +326,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 		moving_character_data.path.remove_at(0)
 
 	moving_character_data.character.position = last_point
+	_update_character_scale(moving_character_data.character)
 	_clear_navigation_path(moving_character_data.character)
 
 

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -296,10 +296,16 @@ func set_active_walkable_area(walkable_area_name: String) -> void:
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
 func _update_character_scale(chr):
 	if chr.on_scaling_region:
-		var polygon_range = chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
-		var scale_range = chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
+		var polygon_range = (
+			chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
+			)
+		var scale_range = (
+			chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
+			)
 
-		var position_from_the_top_of_region = chr.position.y-chr.on_scaling_region['polygon_top_y']
+		var position_from_the_top_of_region = (
+			chr.position.y-chr.on_scaling_region['polygon_top_y']
+			)
 
 		var scale_for_position = (
 			chr.on_scaling_region['scale_top']+(

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -312,8 +312,8 @@ func _update_character_scale(chr):
 				scale_range/polygon_range*position_from_the_top_of_region
 		)
 		)
-		chr.scale.x = scale_for_position
-		chr.scale.y = scale_for_position
+		chr.scale.x = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
+		chr.scale.y = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
 		chr.walk_speed = chr.default_walk_speed/chr.default_scale.x*scale_for_position
 	else:
 		chr.scale = chr.default_scale

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -182,13 +182,38 @@ func clean_characters() -> void:
 		if c is PopochiuCharacter:
 			c.queue_free()
 
+func update_character_scale(chr):
+	if chr.on_scaling_region:
+		var polygon_range = (
+			chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
+			)
+		var scale_range = (
+			chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
+			)
+
+		var position_from_the_top_of_region = (
+			chr.position.y-chr.on_scaling_region['polygon_top_y']
+			)
+
+		var scale_for_position = (
+			chr.on_scaling_region['scale_top']+(
+				scale_range/polygon_range*position_from_the_top_of_region
+		)
+		)
+		chr.scale.x = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
+		chr.scale.y = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
+		chr.walk_speed = chr.default_walk_speed/chr.default_scale.x*scale_for_position
+	else:
+		chr.scale = chr.default_scale
+		chr.walk_speed = chr.default_walk_speed
+
 func update_characters_position(character):
 	character.position = (
 		character.position_stored 
 		if character.position_stored 
 		else character.position
 		)
-	_update_character_scale(character)
+	update_character_scale(character)
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ SET & GET ░░░░
 func get_marker(marker_name: String) -> Marker2D:
@@ -294,30 +319,6 @@ func set_active_walkable_area(walkable_area_name: String) -> void:
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
-func _update_character_scale(chr):
-	if chr.on_scaling_region:
-		var polygon_range = (
-			chr.on_scaling_region['polygon_bottom_y'] - chr.on_scaling_region['polygon_top_y']
-			)
-		var scale_range = (
-			chr.on_scaling_region['scale_bottom'] - chr.on_scaling_region['scale_top']
-			)
-
-		var position_from_the_top_of_region = (
-			chr.position.y-chr.on_scaling_region['polygon_top_y']
-			)
-
-		var scale_for_position = (
-			chr.on_scaling_region['scale_top']+(
-				scale_range/polygon_range*position_from_the_top_of_region
-		)
-		)
-		chr.scale.x = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
-		chr.scale.y = [[scale_for_position, chr.on_scaling_region['scale_min']].max(), chr.on_scaling_region['scale_max']].min()
-		chr.walk_speed = chr.default_walk_speed/chr.default_scale.x*scale_for_position
-	else:
-		chr.scale = chr.default_scale
-		chr.walk_speed = chr.default_walk_speed
 
 func _move_along_path(distance: float, moving_character_data: Dictionary):
 	var last_point: Vector2 =( 
@@ -339,7 +340,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 				moving_character_data.character.position_stored = next_position
 			else:
 				moving_character_data.character.position = next_position
-				_update_character_scale(moving_character_data.character)
+				update_character_scale(moving_character_data.character)
 			return
 
 		distance -= distance_between_points
@@ -347,7 +348,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 		moving_character_data.path.remove_at(0)
 
 	moving_character_data.character.position = last_point
-	_update_character_scale(moving_character_data.character)
+	update_character_scale(moving_character_data.character)
 	_clear_navigation_path(moving_character_data.character)
 
 

--- a/addons/popochiu/popochiu_resources.gd
+++ b/addons/popochiu/popochiu_resources.gd
@@ -106,7 +106,10 @@ const WALKABLE_AREAS_IGNORE := [
 ]
 const REGIONS_IGNORE := [
 	'description',
-	'tint'
+	'tint',
+	'scaling',
+	'scale_top',
+	'scale_bottom'
 ]
 const SNGL_TEMPLATE := '@tool\n' +\
 'extends "%s"\n\n' +\


### PR DESCRIPTION
This is update to my earlier PR.
It resolves 2 bugs observed during further tests:
- characters with bigger collision polygons had tendency to scale exceeding maximum and minimum scale set for top and bottom of region;
-  in some cases scale didn't applied to characters before room's fade in. They either shrinked just after load or didnt scale until any character moved.
Both issues should now be fixed
- scaling works only for main room. Regions in all other rooms have scaling=False and scale_top and _bottom ==1