### PR TITLE
Ref 114: Character sprite scaling update - scaling polygon added

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.tscn
+++ b/addons/popochiu/engine/objects/character/popochiu_character.tscn
@@ -5,15 +5,23 @@
 [node name="Character" type="Area2D"]
 script = ExtResource("1_2xmr4")
 popochiu_placeholder = null
+interaction_polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
 [node name="InteractionPolygon" type="CollisionPolygon2D" parent="."]
+visible = false
 polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
+[node name="ScalingPolygon2D" type="CollisionPolygon2D" parent="."]
+visible = false
+polygon = PackedVector2Array(0, 0, 0, 0, 0, 0, 0, 0)
+
 [node name="BaselineHelper" type="Line2D" parent="."]
+visible = false
 points = PackedVector2Array(-10000, 0, 10000, 0)
 width = 1.0
 
 [node name="WalkToHelper" type="Marker2D" parent="."]
+visible = false
 
 [node name="ColorRect" type="ColorRect" parent="WalkToHelper"]
 offset_left = -2.5
@@ -27,3 +35,4 @@ color = Color(0, 1, 1, 1)
 [node name="Sprite2D" type="Sprite2D" parent="."]
 
 [node name="DialogPos" type="Marker2D" parent="."]
+visible = false

--- a/addons/popochiu/engine/objects/character/popochiu_character.tscn
+++ b/addons/popochiu/engine/objects/character/popochiu_character.tscn
@@ -5,23 +5,18 @@
 [node name="Character" type="Area2D"]
 script = ExtResource("1_2xmr4")
 popochiu_placeholder = null
-interaction_polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
 [node name="InteractionPolygon" type="CollisionPolygon2D" parent="."]
-visible = false
 polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
 [node name="ScalingPolygon2D" type="CollisionPolygon2D" parent="."]
-visible = false
 polygon = PackedVector2Array(0, 0, 0, 0, 0, 0, 0, 0)
 
 [node name="BaselineHelper" type="Line2D" parent="."]
-visible = false
 points = PackedVector2Array(-10000, 0, 10000, 0)
 width = 1.0
 
 [node name="WalkToHelper" type="Marker2D" parent="."]
-visible = false
 
 [node name="ColorRect" type="ColorRect" parent="WalkToHelper"]
 offset_left = -2.5
@@ -35,4 +30,3 @@ color = Color(0, 1, 1, 1)
 [node name="Sprite2D" type="Sprite2D" parent="."]
 
 [node name="DialogPos" type="Marker2D" parent="."]
-visible = false

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -22,6 +22,8 @@ func _ready() -> void:
 	
 	area_entered.connect(_check_area.bind(true))
 	area_exited.connect(_check_area.bind(false))
+	area_shape_entered.connect(_check_scaling.bind(true))
+	area_shape_exited.connect(_check_scaling.bind(false))
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
@@ -61,17 +63,23 @@ func _clear_scaling_region(chr: PopochiuCharacter) -> void:
 		chr.on_scaling_region = {}
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+func _check_scaling(area_rid: RID, area: Area2D, area_shape_index: int, local_shape_index: int, entered: bool):
+	if area is PopochiuCharacter and area.get_node("ScalingPolygon") and area_shape_index == area.get_node("ScalingPolygon").get_index():
+		if entered:
+			if scaling:
+				_update_scaling_region(area)
+				E.current_room._update_character_scale(area)
+		else:
+			_clear_scaling_region(area)
+		
+
 func _check_area(area: PopochiuCharacter, entered: bool) -> void:
+	
 	if area is PopochiuCharacter:
 		if entered:
 			_on_character_entered(area)
-			if scaling:
-				_update_scaling_region(area)
-				E.current_room.update_character_scale(area)
 		else:
 			_on_character_exited(area)
-			_clear_scaling_region(area)
-			E.current_room.update_character_scale(area)
 
 
 func _set_enabled(value: bool) -> void:

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -63,8 +63,14 @@ func _clear_scaling_region(chr: PopochiuCharacter) -> void:
 		chr.on_scaling_region = {}
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
-func _check_scaling(area_rid: RID, area: Area2D, area_shape_index: int, local_shape_index: int, entered: bool):
-	if area is PopochiuCharacter and area.get_node("ScalingPolygon") and area_shape_index == area.get_node("ScalingPolygon").get_index():
+func _check_scaling(
+	area_rid: RID, area: Area2D, area_shape_index: int, local_shape_index: int, entered: bool
+	):
+	if (
+		area is PopochiuCharacter 
+		and area.get_node_or_null("ScalingPolygon") 
+		and area_shape_index == area.get_node("ScalingPolygon").get_index()
+		):
 		if entered:
 			if scaling:
 				_update_scaling_region(area)


### PR DESCRIPTION
characters' InteractionPolygon was a bad candidae to rule  entering and exiting of scaling regions.
- InteractionPolygons needed to be as large as sprite to allow clickability of character;
- polygons used to determine moment of entering or exiting of scaling regions needed to be as small as possible in order to avoid sequence of enters and exits while character shrinks at the region's border.

That made resonable creation of separate Polygon for scaling purpose - ie. ScalingPolygon. 