### PR TITLE
Refs 114: Character sprite scaling fix

### DIFF
--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -74,7 +74,7 @@ func _check_scaling(
 		if entered:
 			if scaling:
 				_update_scaling_region(area)
-				E.current_room._update_character_scale(area)
+				E.current_room.update_character_scale(area)
 		else:
 			_clear_scaling_region(area)
 		

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -130,6 +130,7 @@ func exit_room() -> void:
 	set_physics_process(false)
 	
 	for c in $Characters.get_children():
+		c.position_stored = null
 		$Characters.remove_child(c)
 	
 	_on_room_exited()


### PR DESCRIPTION
In order to solve problems listed in 
https://github.com/mapedorr/popochiu/pull/141
room's method update_character_scale function name had been changed as it's private no more.
unfortunately in next PR:
https://github.com/mapedorr/popochiu/pull/142
one of references in popochiu_region restored the outdated name.

Following PR covers fix of: 
- above mentioned bug and
- avoids transfer of characters' position to the next room (via character's position_stored variable)