### PR TITLE
Refs 101: Main camera position update to smoothly follow anti-glide animated character

### DIFF
--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -149,10 +149,16 @@ func _process(delta: float) -> void:
 		
 		if _shake_timer <= 0.0:
 			stop_camera_shake()
-	elif not Engine.is_editor_hint()\
-	and is_instance_valid(C.camera_owner)\
-	and C.camera_owner.is_inside_tree():
-		main_camera.position = C.camera_owner.position
+	elif (
+	not Engine.is_editor_hint() 
+	and is_instance_valid(C.camera_owner) 
+	and C.camera_owner.is_inside_tree()
+	):
+		main_camera.position = (
+		C.camera_owner.position_stored 
+		if C.camera_owner.position_stored 
+		else C.camera_owner.position
+		)
 
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION
Main camera followed player character's position.
It caused problems because:
- in case of character with anti-glide animation turned on, without smoothed position camera would jump from frame to frame.
- smoothing in Godot 4 works in highly unexpected way, smooth scrolling had to be managed different way:

To avoid it in case of anti-glide animated character camera position had been switched from character's position to his stored_position (variable used to store position between frames - it's equal to position of character with anti-glide animation turned off)   

Happy New Year!!!